### PR TITLE
Add action arguments

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -61,9 +61,12 @@ export class Actions {
             },
             command: {
                 name: "Run command",
-                options: [{ id: "command", type: "dropdown", label: "Command", choices: commands, default: "noop" }],
+                options: [
+                    { id: "command", type: "dropdown", label: "Command", choices: commands, default: "noop" },
+                    { id: "args", type: "textinput", label: "Arguments", tooltip: "Some commands can take some additional arguments or options to prevent the need for additional. " }
+                ],
                 callback: (action) =>
-                    this.send("run-command", { command: action.options.command?.toString() ?? "noop" }),
+                    this.send("run-command", { command: action.options.command?.toString() ?? "noop", arguments: JSON.parse(action.options.args?.trim() || null) }),
             },
         };
     }


### PR DESCRIPTION
I tried to create a button that runs a specific task via `workbench.actions.tasks.runTask` but I wasn't able to specify an individual task inside of Companion. Instead of running a task, it brings up a list of tasks to choose from, but I wanted to create a separate button for each task so I could run them all with a single press.

So looked and found you can pass arguments to commands, but this companion module didn't support it. This is my attempt to support it. I don't have the time to set this up in a way to actually test if it works correctly with companion, so please don't merge and release this without testing it first, but it should at least get this feature rolling.